### PR TITLE
Made size grow up to 20

### DIFF
--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -166,7 +166,11 @@ sample :: forall r a. Seed -> Int -> Gen a -> Array a
 sample seed n g = evalGen sampleGen { newSeed: seed, size: 0 }
   where
   sampleGen = traverse (flip resize g) sizes
-  sizes = range 0 (n - 1) <#> (*2)
+  sizes = range 0 (n - 1) <#> f
+    where
+    f 0 = 2
+    f n | n >= 20 = 20
+    f n = n + 1
 
 -- | Sample a random generator, using a randomly generated seed
 randomSample' :: forall r a. Size -> Gen a -> Eff (random :: RANDOM | r) (Array a)


### PR DESCRIPTION
In Haskell's QuickCheck `sample'` which is used to generate example samples the size is limited to 20. 

https://hackage.haskell.org/package/QuickCheck-2.8.1/docs/src/Test-QuickCheck-Gen.html#sample%27

This duplicates this behaviour and speeds up things a lot. 

This isn't implemented in the same way that it is in Haskell's QuickCheck. It probably should be implemented in `randomSample'` rather than `sample`.
